### PR TITLE
Make a Cairo failure cause sndfile-spectrogram to exit(1), not exit(0)

### DIFF
--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -656,7 +656,7 @@ render_cairo_surface (const RENDER * render, SNDFILE *infile, int samplerate, sf
 	if (surface == NULL || cairo_surface_status (surface) != CAIRO_STATUS_SUCCESS)
 	{	status = cairo_surface_status (surface) ;
 		printf ("Error while creating surface : %s\n", cairo_status_to_string (status)) ;
-		return ;
+		exit(1) ;
 		} ;
 
 	cairo_surface_flush (surface) ;
@@ -665,7 +665,9 @@ render_cairo_surface (const RENDER * render, SNDFILE *infile, int samplerate, sf
 
 	status = cairo_surface_write_to_png (surface, render->pngfilepath) ;
 	if (status != CAIRO_STATUS_SUCCESS)
-		printf ("Error while creating PNG file : %s\n", cairo_status_to_string (status)) ;
+	{	printf ("Error while creating PNG file : %s\n", cairo_status_to_string (status)) ;
+		exit(1) ;
+		} ;
 
 	cairo_surface_destroy (surface) ;
 
@@ -680,7 +682,7 @@ render_sndfile (const RENDER * render)
 
 	if (render->log_freq)
 	{	printf ("Error : --log-freq option not working yet.\n\n") ;
-		return ;
+		exit(1) ;
 		} ;
 
 	memset (&info, 0, sizeof (info)) ;
@@ -688,7 +690,7 @@ render_sndfile (const RENDER * render)
 	infile = sf_open (render->sndfilepath, SFM_READ, &info) ;
 	if (infile == NULL)
 	{	printf ("Error : failed to open file '%s' : \n%s\n", render->sndfilepath, sf_strerror (NULL)) ;
-		return ;
+		exit(1) ;
 		} ;
 
 	render_cairo_surface (render, infile, info.samplerate, info.frames) ;

--- a/src/window.h
+++ b/src/window.h
@@ -15,6 +15,8 @@
 ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+enum WINDOW_FUNCTION { KAISER = 1, NUTTALL = 2 } ;
+
 void calc_kaiser_window (double * data, int datalen, double beta) ;
 
 void calc_nuttall_window (double * data, int datalen) ;


### PR DESCRIPTION
When Cairo init failed, typically because the output image was >32768 wide,
sndfile-sprectogram would exit(0). This makes it exit(1) so that wrapping
shell scripts can more reliably detect sndfile-spectrogram failure.