### PR TITLE
Add Hanning window with --hanning option

### DIFF
--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -197,6 +197,9 @@ apply_window (double * data, int datalen, enum WINDOW_FUNCTION window_function)
 			case NUTTALL:
 				calc_nuttall_window (window, datalen) ;
 				break;
+			case HANNING:
+				calc_hanning_window (window, datalen) ;
+				break;
 			default:
 				printf ("Internal error: Unknown window_function.\n") ;
 				exit (1) ;
@@ -734,6 +737,7 @@ usage_exit (const char * argv0, int error)
 		"        --gray-scale           : Output gray pixels instead of a heat map\n"
 		"        --kaiser               : Use a Kaiser window function (the default)\n"
 		"        --nuttall              : Use a Nuttall window function\n"
+		"        --hanning              : Use a Hanning window function\n"
 		) ;
 
 	exit (error) ;
@@ -783,6 +787,11 @@ main (int argc, char * argv [])
 
 		if (strcmp (argv [k], "--nuttall") == 0)
 		{	render.window_function = NUTTALL ;
+			continue ;
+			} ;
+
+		if (strcmp (argv [k], "--hanning") == 0)
+		{	render.window_function = HANNING ;
 			continue ;
 			} ;
 

--- a/src/window.c
+++ b/src/window.c
@@ -79,6 +79,23 @@ calc_nuttall_window (double * data, int datalen)
 	return ;
 } /* calc_nuttall_window */
 
+void
+calc_hanning_window (double * data, int datalen)
+{
+	int k ;
+
+	/*
+	**	Hanning window function from :
+	**
+	**	http://en.wikipedia.org/wiki/Window_function
+	*/
+
+	for (k = 0 ; k < datalen ; k++)
+		data [k] = 0.5 * (1.0 - cos(2.0 * M_PI * k / (datalen - 1))) ;
+
+	return ;
+} /* calc_hanning_window */
+
 /*==============================================================================
 */
 

--- a/src/window.h
+++ b/src/window.h
@@ -15,8 +15,10 @@
 ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-enum WINDOW_FUNCTION { KAISER = 1, NUTTALL = 2 } ;
+enum WINDOW_FUNCTION { KAISER = 1, NUTTALL = 2, HANNING = 3 } ;
 
 void calc_kaiser_window (double * data, int datalen, double beta) ;
 
 void calc_nuttall_window (double * data, int datalen) ;
+
+void calc_hanning_window (double * data, int datalen) ;


### PR DESCRIPTION
The Hanning window is the most widely used woth FFTs. Although the other two show better frequency- and time-definition, the Hanning window sometimes reveals more detail than the existing two.

As a more well-known window (no other spectrogram program has Kaiser or Nuttall!) it is also useful to be able to compare the output with that of other programs to eliminate factors that might depend on the window function in use.