### PR TITLE
Add --hann option to use a Hann window function.

### DIFF
--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -197,6 +197,9 @@ apply_window (double * data, int datalen, enum WINDOW_FUNCTION window_function)
 			case NUTTALL:
 				calc_nuttall_window (window, datalen) ;
 				break;
+			case HANN:
+				calc_hann_window (window, datalen) ;
+				break;
 			default:
 				printf ("Internal error: Unknown window_function.\n") ;
 				exit (1) ;
@@ -734,6 +737,7 @@ usage_exit (const char * argv0, int error)
 		"        --gray-scale           : Output gray pixels instead of a heat map\n"
 		"        --kaiser               : Use a Kaiser window function (the default)\n"
 		"        --nuttall              : Use a Nuttall window function\n"
+		"        --hann                 : Use a Hann window function\n"
 		) ;
 
 	exit (error) ;
@@ -783,6 +787,11 @@ main (int argc, char * argv [])
 
 		if (strcmp (argv [k], "--nuttall") == 0)
 		{	render.window_function = NUTTALL ;
+			continue ;
+			} ;
+
+		if (strcmp (argv [k], "--hann") == 0)
+		{	render.window_function = HANN ;
 			continue ;
 			} ;
 

--- a/src/window.c
+++ b/src/window.c
@@ -79,6 +79,23 @@ calc_nuttall_window (double * data, int datalen)
 	return ;
 } /* calc_nuttall_window */
 
+void
+calc_hann_window (double * data, int datalen)
+{
+	int k ;
+
+	/*
+	**	Hann window function from :
+	**
+	**	http://en.wikipedia.org/wiki/Window_function
+	*/
+
+	for (k = 0 ; k < datalen ; k++)
+		data [k] = 0.5 * (1.0 - cos(2.0 * M_PI * k / (datalen - 1))) ;
+
+	return ;
+} /* calc_hann_window */
+
 /*==============================================================================
 */
 

--- a/src/window.h
+++ b/src/window.h
@@ -15,8 +15,10 @@
 ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-enum WINDOW_FUNCTION { KAISER = 1, NUTTALL = 2 } ;
+enum WINDOW_FUNCTION { KAISER = 1, NUTTALL = 2, HANN = 3 } ;
 
 void calc_kaiser_window (double * data, int datalen, double beta) ;
 
 void calc_nuttall_window (double * data, int datalen) ;
+
+void calc_hann_window (double * data, int datalen) ;


### PR DESCRIPTION

The Hann window is the most widely used with FFTs. Although the other two show better frequency- and time-definition, the Hann window sometimes reveals more detail than the existing two.

As a more well-known window it is also useful to be able to compare the output with that of other programs to eliminate factors that might depend on the window function in use.
