### PR TITLE
Fix the interference pattern "florets" artifact in the output.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -65,22 +65,6 @@ sfx_mix_mono_read_double (SNDFILE * file, double * data, sf_count_t datalen)
 	return dataout ;
 } /* sfx_mix_mono_read_double */
 
-
-double
-calc_magnitude (const double * freq, int freqlen, double * magnitude)
-{
-	int k ;
-	double max = 0.0 ;
-
-	for (k = 1 ; k < freqlen / 2 ; k++)
-	{	magnitude [k] = sqrt (freq [k] * freq [k] + freq [freqlen - k - 1] * freq [freqlen - k - 1]) ;
-		max = MAX (max, magnitude [k]) ;
-		} ;
-	magnitude [0] = 0.0 ;
-
-	return max ;
-} /* calc_magnitude */
-
 int
 parse_int_or_die (const char * input, const char * value_name)
 {	char * endptr ;

--- a/src/common.h
+++ b/src/common.h
@@ -53,6 +53,4 @@ extern const char * font_family ;
 
 sf_count_t sfx_mix_mono_read_double (SNDFILE * file, double * data, sf_count_t datalen) ;
 
-double calc_magnitude (const double * freq, int freqlen, double * magnitude) ;
-
 int parse_int_or_die (const char * input, const char * value_name) ;

--- a/src/spectrogram.c
+++ b/src/spectrogram.c
@@ -529,6 +529,27 @@ is_good_speclen (int n)
 						|| ((n % 13 == 0) && is_2357 (n / 13)) ;
 }
 
+/* Convert from FFTW's "half complex" format to an array of magnitudes.
+ * In HC format, the values are stored:
+ * r0, r1, r2 ... r(n/2), i(n+1)/2-1 .. i2, i1
+ */
+static double
+calc_magnitude (const double * freq, int freqlen, double * magnitude)
+{
+	int k ;
+	double max = 0.0 ;
+
+	for (k = 1 ; k < freqlen / 2 ; k++)
+	{	magnitude [k] = sqrt (freq [k] * freq [k] + freq [freqlen - k] * freq [freqlen - k]) ;
+		max = MAX (max, magnitude [k]) ;
+		} ;
+	magnitude [0] = fabs (freq [0]) ;
+	max = MAX (max, magnitude [0]) ;
+
+	return max ;
+} /* calc_magnitude */
+
+
 static void
 render_to_surface (const RENDER * render, SNDFILE *infile, int samplerate, sf_count_t filelen, cairo_surface_t * surface)
 {


### PR DESCRIPTION
calc_magnitude was incorrectly decoding the "half-complex" output format
used by FFTW, summing the real and imaginary parts of different
frequency bands instead of those for the same frequency band.

This change rectifies that out-by-one error and also sets magnitudes[0]
which previously was always left black for some reason.
It also moves calc_magnitudes() from common.c into spectrogram.c as it is
FFTW-specific and this in the only place it is used.