### PR TITLE
Fix broken factorial cache

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -137,6 +137,8 @@ factorial (int val)
 	for (k = have_entry + 1 ; k <= val ; k++)
 		memory [k] = k * memory [k - 1] ;
 
+	have_entry = val ;
+
 	return memory [val] ;
 } /* factorial */
 


### PR DESCRIPTION
The factorial function never used its result cache because
the line of code to remember what it already knew was missing.
This adds the missing line of code.